### PR TITLE
Add subdomain support in script

### DIFF
--- a/scripts/custom-docker-compose
+++ b/scripts/custom-docker-compose
@@ -14,11 +14,11 @@
 
 
 set -e
-# set -o xtrace
+#set -o xtrace
 
 VERSION="1.22.0"
 IMAGE="docker/compose:$VERSION"
-echo $VOLUMES
+echo "Using volumes: ${VOLUMES}"
 
 
 # Setup options for connecting to docker host

--- a/src/config.go
+++ b/src/config.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"os"
 	"path"
 
@@ -72,10 +71,7 @@ type Server struct {
 }
 
 // ServersList is the list of all the servers that we have
-var ServersList = []Server{
-	Server{"Deploy1", "deploy1"},
-	Server{"Deploy2", "deploy2"},
-}
+var ServersList []Server
 
 // ServerOptionsByte is the byte array of the options of server
 var ServerOptionsByte []byte
@@ -112,19 +108,14 @@ func initialize() {
 		log.Fatal("Github Secret is not present in environment, Exiting")
 	}
 
-	serverOptions := make(map[string]interface{})
-	serverOptions["options"] = ServersList
-	var err error
-	ServerOptionsByte, err = json.Marshal(serverOptions)
-	if err != nil {
-		panic(err)
-	}
-
 	log.Info("Setting Up Log directory")
 	createDirIfNotExist(path.Join(LogDir, "deploy"))
 	log.Infof("Log directory %s created", path.Join(LogDir, "deploy"))
 	createDirIfNotExist(path.Join(LogDir, "git"))
 	log.Infof("Log directory %s created", path.Join(LogDir, "git"))
+
+	log.Info("Getting Servers Info")
+	getServers()
 
 }
 
@@ -147,8 +138,8 @@ var DialogMenu = []byte(`{
 			"data_source": "external"
 		},
 		{
-			"label": "DNS Entry prefix",
-			"name": "dns",
+			"label": "Subdomain",
+			"name": "subdomain",
 			"type": "text"
 		},
 		{

--- a/src/deploy.go
+++ b/src/deploy.go
@@ -45,10 +45,11 @@ func deployGoRoutine(callbackID string,
 func DeployApp(submissionData map[string]interface{}) ([]byte, error) {
 	gitRepoURL := submissionData["git_repo"].(string)
 	serverName := submissionData["server_name"].(string)
+	subdomain := submissionData["subdomain"].(string)
 	branch := DefaultBranch
 
 	log.Infof("Calling %s to deploy", DeployScriptName)
 	output, err := exec.Command(DeployScriptName, "-n", "-u",
-		gitRepoURL, "-b", branch, "-m", serverName).CombinedOutput()
+		gitRepoURL, "-b", branch, "-m", serverName, "-s", subdomain).CombinedOutput()
 	return output, err
 }

--- a/src/deploy.go
+++ b/src/deploy.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"os/exec"
 	"path"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -15,8 +17,9 @@ func deployGoRoutine(callbackID string,
 		return
 	}
 
-	log.Infof("Beginning Deployment of %s on server %s with callback_id as %s",
-		submissionDataMap["git_repo"], submissionDataMap["server_name"],
+	log.Infof("Beginning Deployment of %s on server %s with subdomain as %s "+
+		"with callback_id as %s", submissionDataMap["git_repo"],
+		submissionDataMap["server_name"], submissionDataMap["subdomain"],
 		callbackID)
 
 	deployOut, err := DeployApp(submissionDataMap)
@@ -28,16 +31,16 @@ func deployGoRoutine(callbackID string,
 		log.Error("Deployment Failed")
 		_ = chatPostMessage(submissionDataMap["channel"].(string),
 			"Deployment of "+submissionDataMap["git_repo"].(string)+" on "+
-				submissionDataMap["server_name"].(string)+
-				" FAILED\n\n  "+"See logs at: "+ServerURL+"/logs/deploy/"+
-				callbackID+".txt", nil)
+				submissionDataMap["server_name"].(string)+" with subdomain "+
+				submissionDataMap["subdomain"].(string)+" FAILED\n\n  "+
+				"See logs at: "+ServerURL+"/logs/deploy/"+callbackID+".txt", nil)
 	} else {
 		log.Info("Deployment Successful")
 		_ = chatPostMessage(submissionDataMap["channel"].(string),
 			"Deployment of "+submissionDataMap["git_repo"].(string)+" on "+
-				submissionDataMap["server_name"].(string)+
-				" Successful\n\n  "+"See logs at: "+ServerURL+"/logs/deploy/"+
-				callbackID+".txt", nil)
+				submissionDataMap["server_name"].(string)+" with subdomain "+
+				submissionDataMap["subdomain"].(string)+" Successful\n\n  "+
+				"See logs at: "+ServerURL+"/logs/deploy/"+callbackID+".txt", nil)
 	}
 }
 
@@ -52,4 +55,28 @@ func DeployApp(submissionData map[string]interface{}) ([]byte, error) {
 	output, err := exec.Command(DeployScriptName, "-n", "-u",
 		gitRepoURL, "-b", branch, "-m", serverName, "-s", subdomain).CombinedOutput()
 	return output, err
+}
+
+func getServers() {
+
+	log.Info("Executing docker-machine to get list of servers")
+	cmd := "docker-machine ls --filter state=Running | tail -n+2 | awk '{print $1}'"
+	output, err := exec.Command("bash", "-c", cmd).CombinedOutput()
+	if err != nil {
+		log.Fatal("Cannot get information about servers")
+	}
+	machines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	for _, el := range machines {
+		ServersList = append(ServersList, Server{
+			Name:       strings.Title(el),
+			DeployName: el,
+		})
+	}
+	log.Info("Servers Present: ", ServersList)
+	serverOptions := make(map[string]interface{})
+	serverOptions["options"] = ServersList
+	ServerOptionsByte, err = json.Marshal(serverOptions)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/src/httpHandlers.go
+++ b/src/httpHandlers.go
@@ -95,6 +95,7 @@ func dataOptionsHandler(w http.ResponseWriter, r *http.Request) {
 
 	log.Infof("Data-options requested %s", optionType)
 	if optionType == "server_name" {
+		getServers()
 		w.Write(ServerOptionsByte)
 	} else if optionType == "git_repo" {
 		getGitRepos()


### PR DESCRIPTION
Modified script for subdomain support.

This assumes that the data given to deploy.go will have a key named "subdoman".

Also, this will only work if the docker-compose files of all the projects have
`VIRTUAL_HOST` declared but not set in `environment` key.