### PR TITLE
Add old state param to SetState

### DIFF
--- a/src/controllers/deploy.go
+++ b/src/controllers/deploy.go
@@ -46,6 +46,7 @@ func internaldeploy(a *history.ActionInstance) ([]byte, error) {
 
 	// This is a value, and thus modifying it does not change the original state in the history map
 	state := history.GetState(a.RepoURL)
+	oldState := state
 
 	var output []byte
 	var err error
@@ -69,7 +70,7 @@ func internaldeploy(a *history.ActionInstance) ([]byte, error) {
 		state.Access = a.Access
 		state.Server = a.Server
 		state.Status = "deploying"
-		if err1 := history.SetState(a.RepoURL, state); err1 != nil {
+		if err1 := history.SetState(a.RepoURL, oldState, state); err1 != nil {
 			log.Infof("setting state to deploying failed - %v", err1)
 			output = []byte("InternalDeployError: cannot set state to deploying - " + err1.Error())
 			return output, err1
@@ -77,10 +78,10 @@ func internaldeploy(a *history.ActionInstance) ([]byte, error) {
 		output, err = exec.Command(deployScriptName, "-n", "-u", a.RepoURL, "-b", branch, "-m", a.Server, "-s", a.Subdomain, "-a", a.Access).CombinedOutput()
 		if err != nil {
 			state.Status = "stopped"
-			history.SetState(a.RepoURL, state)
+			history.SetState(a.RepoURL, oldState, state)
 		} else {
 			state.Status = "running"
-			history.SetState(a.RepoURL, state)
+			history.SetState(a.RepoURL, oldState, state)
 		}
 
 	}

--- a/src/controllers/stop.go
+++ b/src/controllers/stop.go
@@ -41,6 +41,7 @@ func stop(callbackID string, data map[string]interface{}) {
 // internalStop actually runs the script to stop the given app.
 func internalStop(a *history.ActionInstance) ([]byte, error) {
 	state := history.GetState(a.RepoURL)
+	oldState := state
 
 	var output []byte
 	var err error
@@ -57,13 +58,13 @@ func internalStop(a *history.ActionInstance) ([]byte, error) {
 	case "running":
 		log.Infof("calling %s to stop service(%s)", stopScriptName, a.RepoURL)
 		state.Status = "stopping"
-		history.SetState(a.RepoURL, state)
+		history.SetState(a.RepoURL, oldState, state)
 		if output, err = exec.Command(stopScriptName, state.Subdomain, a.RepoURL, state.Server).CombinedOutput(); err != nil {
 			state.Status = "running"
-			history.SetState(a.RepoURL, state)
+			history.SetState(a.RepoURL, oldState, state)
 		} else {
 			state.Status = "stopped"
-			history.SetState(a.RepoURL, state)
+			history.SetState(a.RepoURL, oldState, state)
 		}
 	default:
 		log.Infof("service(%s) is already stopped", a.RepoURL)


### PR DESCRIPTION
Implements a compareAndSwap in SetState and the state is only modified if the old state supplied matches the current state

Haven't used any tag since I couldn't think of a way to associate it with the repoURL without modifying the history map, and comparing the structs is better than calculating tag at each point and comparing.

Fixes #30 