### PR TITLE
Make tags for states, use to ensure thread safety

### DIFF
--- a/src/controllers/logs.go
+++ b/src/controllers/logs.go
@@ -50,7 +50,7 @@ func logs(callbackID string, data map[string]interface{}) {
 func internalLogs(data map[string]interface{}) ([]byte, error) {
 	gitRepoURL := data["git_repo"].(string)
 	tailCount := data["tail_count"].(string)
-	current := history.GetState(gitRepoURL)
+	current, _ := history.GetState(gitRepoURL)
 	serverName := current.Server
 	if current.Status != "running" {
 		log.Infof("service %s is not running, cannot fetch logs", gitRepoURL)

--- a/src/controllers/redeploy.go
+++ b/src/controllers/redeploy.go
@@ -6,7 +6,7 @@ import (
 
 func redeploy(callbackID string, data map[string]interface{}) {
 	stop(callbackID, data)
-	state := history.GetState(data["git_repo"].(string))
+	state, _ := history.GetState(data["git_repo"].(string))
 	if state.Status == "stopped" {
 		data["subdomain"] = state.Subdomain
 		data["access"] = state.Access


### PR DESCRIPTION
Tags are used as identifiers for the state, to ensure no other thread
has changed the thread in global history when setting a new state

Fixes #30 