### PR TITLE
Explicitly state variables to substitute

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -572,13 +572,8 @@ nginxEntry() {
     export denied=""
   fi
 
-  ## TODO: Look for a better way to do it
-  export request_method="\$request_method"
-  export http_upgrade="\$http_upgrade"
-  export host="\$host"
-  export request_uri="\$request_uri"
-  export proxy_add_x_forwarded_for="\$proxy_add_x_forwarded_for"
-  envsubst < /usr/local/bin/nginx_template > ./sites-available/${subdomain}
+  export subst_vars='$allowed $allowed2 $allowed3 $denied $ip $subdomain $machine_name $GLOBAL_DOMAIN'
+  envsubst "$subst_vars" < /usr/local/bin/nginx_template > ./sites-available/${subdomain}
   ln -s /etc/nginx/sites-available/${subdomain} /etc/nginx/sites-enabled/${subdomain}
 
   export subdoman=


### PR DESCRIPTION
This uses functionality provided by `envsubst` which allows us to specify the variables it will substitute, and we won't have to add another export whenever we add something to the nginx template.

An example of how this works:

```bash
export a=1
export b=2
echo '$a $b' | envsubst '$a'
```

This will output `1 $b`