### PR TITLE
Regenerate nginx entries on startup

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -52,6 +52,7 @@ __base="$(basename "${__file}" .sh)"
 # Define the environment variables (and their defaults) that this script depends on
 LOG_LEVEL="${LOG_LEVEL:-6}" # 7 = debug -> 0 = emergency
 NO_COLOR="${NO_COLOR:-}"    # true = disable color. otherwise autodetected
+REGEN_NGINX="${REGEN_NGINX:-}"    # true = restart deploybot and regenerate nginx entries. otherwise operate normally.
 
 
 ### Functions
@@ -144,6 +145,7 @@ function help () {
   -d --debug       Enables debug mode
   -h --help        This page
   -n --no-color    Disable color output
+  -r --regenerate-nginx     Restart deploybot and regenerate nginx entries
 EOF
 
 # shellcheck disable=SC2015
@@ -345,6 +347,11 @@ fi
 # verbose mode
 if [[ "${arg_v:?}" = "1" ]]; then
   set -o verbose
+fi
+
+# regenerate nginx templates mode
+if [[ "${arg_r:?}" = "1" ]]; then
+  REGEN_NGINX=true
 fi
 
 # no color mode
@@ -627,13 +634,19 @@ if [[ "${arg_s:-}" ]]; then
   ## If we are giving custom subdomain
   populateVirtualHost ${arg_s} ${__machine_name}
 fi
-pullRepository "${__repo_url}" "${__repo_branch}" "${__repo_dir}"
-analyzeRepository "${__repo_dir}"
-decryptEnv "${__repo_dir}"
-pullImages "${__repo_dir}"
-buildImage "${__repo_dir}"
-pushImages "${__repo_dir}"
-deployImage "${__repo_dir}"
-nginxEntry ${arg_s} ${__machine_name} ${__service_access}
-saveCompose "${__repo_name}" "${__repo_dir}"
-cleanup "${__temp_dir}"
+
+if [ "$REGEN_NGINX" = false ] ; then 
+    pullRepository "${__repo_url}" "${__repo_branch}" "${__repo_dir}"
+    analyzeRepository "${__repo_dir}"
+    decryptEnv "${__repo_dir}"
+    pullImages "${__repo_dir}"
+    buildImage "${__repo_dir}"
+    pushImages "${__repo_dir}"
+    deployImage "${__repo_dir}"
+    nginxEntry ${arg_s} ${__machine_name} ${__service_access}
+    saveCompose "${__repo_name}" "${__repo_dir}"
+    cleanup "${__temp_dir}"
+else
+    nginxEntry ${arg_s} ${__machine_name} ${__service_access}
+fi
+

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -52,7 +52,7 @@ __base="$(basename "${__file}" .sh)"
 # Define the environment variables (and their defaults) that this script depends on
 LOG_LEVEL="${LOG_LEVEL:-6}" # 7 = debug -> 0 = emergency
 NO_COLOR="${NO_COLOR:-}"    # true = disable color. otherwise autodetected
-REGEN_NGINX="${REGEN_NGINX:-}"    # true = restart deploybot and regenerate nginx entries. otherwise operate normally.
+REGENERATE_NGINX="${REGENERATE_NGINX:-}"    # true = restart deploybot and regenerate nginx entries. otherwise operate normally.
 
 
 ### Functions
@@ -351,7 +351,7 @@ fi
 
 # regenerate nginx templates mode
 if [[ "${arg_r:?}" = "1" ]]; then
-  REGEN_NGINX=true
+  REGENERATE_NGINX=true
 fi
 
 # no color mode
@@ -635,7 +635,7 @@ if [[ "${arg_s:-}" ]]; then
   populateVirtualHost ${arg_s} ${__machine_name}
 fi
 
-if [ "$REGEN_NGINX" = false ] ; then 
+if [ "$REGENERATE_NGINX" = false ] ; then 
     pullRepository "${__repo_url}" "${__repo_branch}" "${__repo_dir}"
     analyzeRepository "${__repo_dir}"
     decryptEnv "${__repo_dir}"

--- a/src/controllers/deploy.go
+++ b/src/controllers/deploy.go
@@ -78,7 +78,7 @@ func internaldeploy(a *history.ActionInstance) ([]byte, error) {
 			output = []byte("InternalDeployError: cannot set state to deploying - " + err1.Error())
 			return output, err1
 		}
-		output, err = exec.Command(deployScriptName, "-n", "-u", a.RepoURL, "-b", branch, "-m", a.Server, "-s", a.Subdomain, "-a", a.Access).CombinedOutput()
+		output, err = exec.Command(deployScriptName, GetDeployArgs(a.RepoURL, branch, a.Server, a.Subdomain, a.Access)...).CombinedOutput()
 		if err != nil {
 			state.Status = "stopped"
 		} else {
@@ -94,4 +94,9 @@ func internaldeploy(a *history.ActionInstance) ([]byte, error) {
 		log.Infof("setting state to %v successful", state.Status)
 	}
 	return output, err
+}
+
+// GetDeployArgs - Get arguments to pass to deploy script as a string array
+func GetDeployArgs(repoURL string, branch string, server string, subdomain string, access string) []string {
+	return []string{"-n", "-u", repoURL, "-b", branch, "-m", server, "-s", subdomain, "-a", access}
 }

--- a/src/controllers/deploy.go
+++ b/src/controllers/deploy.go
@@ -6,10 +6,10 @@ import (
 	"os/exec"
 	"path"
 
+	"github.com/devclub-iitd/DeployBot/src/discord"
 	"github.com/devclub-iitd/DeployBot/src/helper"
 	"github.com/devclub-iitd/DeployBot/src/history"
 	"github.com/devclub-iitd/DeployBot/src/slack"
-	"github.com/devclub-iitd/DeployBot/src/discord"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/src/controllers/deploy.go
+++ b/src/controllers/deploy.go
@@ -78,7 +78,9 @@ func internaldeploy(a *history.ActionInstance) ([]byte, error) {
 			output = []byte("InternalDeployError: cannot set state to deploying - " + err1.Error())
 			return output, err1
 		}
-		output, err = exec.Command(deployScriptName, GetDeployArgs(a.RepoURL, branch, a.Server, a.Subdomain, a.Access)...).CombinedOutput()
+
+		args := GetDeployArgs(a.RepoURL, branch, a.Server, a.Subdomain, a.Access)
+		output, err = exec.Command(deployScriptName, args...).CombinedOutput()
 		if err != nil {
 			state.Status = "stopped"
 		} else {

--- a/src/controllers/restart.go
+++ b/src/controllers/restart.go
@@ -9,17 +9,18 @@ import (
 
 // NginxRegenerate - Regenerate nginx entries for all deployed services
 func NginxRegenerate() (string, error) {
-	for repoURL, service := range *history.GetHistory() {
-		state := service.Current
-		branch := defaultBranch
-		_, err := exec.Command(deployScriptName, "-n", "-u", repoURL, "-b", branch, "-m", state.Server, "-s", state.Subdomain, "-a", state.Access, "-r").CombinedOutput()
+	branch := defaultBranch
+	for repoURL, state := range history.Services() {
+		args := GetDeployArgs(repoURL, branch, state.Server, state.Subdomain, state.Access)
+		args = append(args, "-r")
+
+		_, err := exec.Command(deployScriptName, args...).CombinedOutput()
+
 		if err != nil {
-			state.Status = "stopped"
 			return repoURL, err
 		}
-		log.Infof("Nginx entry regenerated for repoURL: %s, subdomain: %s, branch: %s", repoURL, state.Subdomain, branch)
-		state.Status = "running"
 
+		log.Infof("Nginx entry regenerated for repoURL: %s, subdomain: %s, branch: %s", repoURL, state.Subdomain, branch)
 	}
 	return "", nil
 }

--- a/src/controllers/restart.go
+++ b/src/controllers/restart.go
@@ -1,0 +1,25 @@
+package controllers
+
+import (
+	"os/exec"
+
+	"github.com/devclub-iitd/DeployBot/src/history"
+	log "github.com/sirupsen/logrus"
+)
+
+// NginxRegenerate - Regenerate nginx entries for all deployed services
+func NginxRegenerate() (string, error) {
+	for repoURL, service := range *history.GetHistory() {
+		state := service.Current
+		branch := defaultBranch
+		_, err := exec.Command(deployScriptName, "-n", "-u", repoURL, "-b", branch, "-m", state.Server, "-s", state.Subdomain, "-a", state.Access, "-r").CombinedOutput()
+		if err != nil {
+			state.Status = "stopped"
+			return repoURL, err
+		}
+		log.Infof("Nginx entry regenerated for repoURL: %s, subdomain: %s, branch: %s", repoURL, state.Subdomain, branch)
+		state.Status = "running"
+
+	}
+	return "", nil
+}

--- a/src/controllers/restart.go
+++ b/src/controllers/restart.go
@@ -7,10 +7,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// NginxRegenerate - Regenerate nginx entries for all deployed services
+// NginxRegenerate - Regenerate nginx entries for all deployed and running services
 func NginxRegenerate() (string, error) {
 	branch := defaultBranch
 	for repoURL, state := range history.Services() {
+		if state.Status != "running" {
+			continue
+		}
 		args := GetDeployArgs(repoURL, branch, state.Server, state.Subdomain, state.Access)
 		args = append(args, "-r")
 

--- a/src/go.mod
+++ b/src/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481
+	github.com/onsi/ginkgo v1.14.2 // indirect
+	github.com/onsi/gomega v1.10.4 // indirect
 	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.5.0
 	github.com/teris-io/shortid v0.0.0-20171029131806-771a37caa5cf

--- a/src/history/history.go
+++ b/src/history/history.go
@@ -202,8 +202,3 @@ func subdomainAvailable(subdomain string) bool {
 	}
 	return true
 }
-
-// GetHistory - Returns the history instance
-func GetHistory() *map[string]*Service {
-	return &history
-}

--- a/src/history/history.go
+++ b/src/history/history.go
@@ -202,3 +202,8 @@ func subdomainAvailable(subdomain string) bool {
 	}
 	return true
 }
+
+// GetHistory - Returns the history instance
+func GetHistory() *map[string]*Service {
+	return &history
+}

--- a/src/main.go
+++ b/src/main.go
@@ -19,6 +19,12 @@ func main() {
 	}
 	log.Info("initialization of server completed")
 
+	// Regenerate NGINX templates on restart
+	repoURL, err := controllers.NginxRegenerate()
+	if err != nil {
+		log.Errorf("Could not regenerate NGINX template for repo: %s, details: %v", repoURL, err)
+	}
+
 	// Slack related HTTP handlers
 	http.HandleFunc("/slack/commands/deploy/", slack.DeployCommandHandler)
 	http.HandleFunc("/slack/commands/stop/", slack.StopCommandHandler)

--- a/src/main.go
+++ b/src/main.go
@@ -13,17 +13,19 @@ import (
 )
 
 func main() {
-	log.Info("beginning initialization of server")
-	if err := options.Initialize(); err != nil {
-		log.Fatalf("cannot initialize server - %v", err)
-	}
-	log.Info("initialization of server completed")
+	log.Info("Initializaing server")
 
 	// Regenerate NGINX templates on restart
-	repoURL, err := controllers.NginxRegenerate()
-	if err != nil {
-		log.Errorf("Could not regenerate NGINX template for repo: %s, details: %v", repoURL, err)
+	if repoURL, err := controllers.NginxRegenerate(); err != nil {
+		log.Fatalf("Could not regenerate NGINX template for repo: %s, details: %v", repoURL, err)
 	}
+
+	// Initialize from options
+	if err := options.Initialize(); err != nil {
+		log.Fatalf("Cannot initialize server - %v", err)
+	}
+
+	log.Info("Initialization of server completed")
 
 	// Slack related HTTP handlers
 	http.HandleFunc("/slack/commands/deploy/", slack.DeployCommandHandler)


### PR DESCRIPTION
## Changes
- Added a `-r` flag to `deploy.sh`. When this flag is set only the `nginxEntry` function is run.
- The file `src/controllers/restart.go` contains a `nginxRegenerate()` method that loops over all services and executes the `deploy.sh` script with the `-r` flag set. This method is called in `main.go` 
### TODO
- Testing whether everything works or not sequentially!
- nginx entry generation can be parallelised and go routines can be used

